### PR TITLE
FEATURE: custom log location

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,6 +391,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tokio-util",
  "tower 0.4.13",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ html2md = "0.2.14"
 [dev-dependencies]
 # Testing utilities
 mockito = "1.2"
+tempfile = "3.8"
 
 # Main binary with subcommands
 [[bin]]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ cargo run --bin cratedocs test --tool lookup_crate --crate-name tokio --output t
 
 By default, the HTTP server will listen on `http://127.0.0.1:8080/sse`.
 
+## Configuration
+
+### Log Directory
+
+You can configure where log files are stored by setting the `CRATEDOCS_LOG_DIR` environment variable:
+
+```bash
+# Use a custom log directory
+CRATEDOCS_LOG_DIR=/var/log/cratedocs cargo run --bin cratedocs stdio
+
+# Use a temporary directory
+CRATEDOCS_LOG_DIR=/tmp/cratedocs-logs cargo run --bin cratedocs stdio
+```
+
+If not set, logs will be stored in the default `logs/` directory in the current working directory.
+
 ## Available Tools
 
 The server provides the following tools:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,25 @@ You can configure where log files are stored by setting the `CRATEDOCS_LOG_DIR` 
 CRATEDOCS_LOG_DIR=/var/log/cratedocs cargo run --bin cratedocs stdio
 ```
 
+Or if you are setting it up in `mcp.json`, you can use the following standarf format (pending your client supports it):
+```json
+{
+    "mcpServers": {
+        "cratedocs": {
+            "command": "cratedocs",
+            "args" : [
+                "stdio"
+            ],
+            "env": {
+                "CRATEDOCS_LOG_DIR": "/tmp/cratedocs_logs"
+            },
+            "disabled": false
+        }
+    }
+}
+```
+*Note: The above example requires you to have the bin `cratedocs` installed and available in your `$PATH`*
+
 If not set, logs will be stored in the default `logs/` directory in the current working directory.
 
 ## Available Tools

--- a/README.md
+++ b/README.md
@@ -77,9 +77,6 @@ You can configure where log files are stored by setting the `CRATEDOCS_LOG_DIR` 
 ```bash
 # Use a custom log directory
 CRATEDOCS_LOG_DIR=/var/log/cratedocs cargo run --bin cratedocs stdio
-
-# Use a temporary directory
-CRATEDOCS_LOG_DIR=/tmp/cratedocs-logs cargo run --bin cratedocs stdio
 ```
 
 If not set, logs will be stored in the default `logs/` directory in the current working directory.

--- a/src/bin/cratedocs.rs
+++ b/src/bin/cratedocs.rs
@@ -77,6 +77,20 @@ enum Commands {
     },
 }
 
+/// Get the log directory from environment variable or default
+fn get_log_directory() -> String {
+    let log_dir = std::env::var("CRATEDOCS_LOG_DIR")
+        .unwrap_or_else(|_| "logs".to_string())
+        .trim()
+        .to_string();
+    
+    if log_dir.is_empty() {
+        "logs".to_string()
+    } else {
+        log_dir
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -110,7 +124,8 @@ async fn main() -> Result<()> {
 
 async fn run_stdio_server(debug: bool) -> Result<()> {
     // Set up file appender for logging
-    let file_appender = RollingFileAppender::new(Rotation::DAILY, "logs", "stdio-server.log");
+    let log_dir = get_log_directory();
+    let file_appender = RollingFileAppender::new(Rotation::DAILY, log_dir, "stdio-server.log");
 
     // Initialize the tracing subscriber with file logging
     let level = if debug { tracing::Level::DEBUG } else { tracing::Level::INFO };

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -94,3 +94,37 @@ async fn test_unimplemented_apis() {
     let result = router.get_prompt("test").await;
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn test_configurable_log_directory() {
+    use std::env;
+    use tempfile::TempDir;
+
+    // Create a temporary directory for testing
+    let temp_dir = TempDir::new().expect("Failed to create temp directory");
+    let temp_path = temp_dir.path().to_str().unwrap();
+    
+    // Set the environment variable to the temp directory
+    env::set_var("CRATEDOCS_LOG_DIR", temp_path);
+    
+    // Test that the get_log_directory function returns the custom path
+    // Note: We can't easily test the actual logging without running the full server,
+    // but we can test that the environment variable is read correctly
+    let log_dir = std::env::var("CRATEDOCS_LOG_DIR").unwrap_or_else(|_| "logs".to_string());
+    assert_eq!(log_dir, temp_path);
+    
+    // Clean up
+    env::remove_var("CRATEDOCS_LOG_DIR");
+}
+
+#[tokio::test]
+async fn test_default_log_directory_behavior() {
+    use std::env;
+    
+    // Ensure the environment variable is not set
+    env::remove_var("CRATEDOCS_LOG_DIR");
+    
+    // Test that the default behavior still works
+    let log_dir = std::env::var("CRATEDOCS_LOG_DIR").unwrap_or_else(|_| "logs".to_string());
+    assert_eq!(log_dir, "logs");
+}


### PR DESCRIPTION
Created a feature that allows the user to define a `CRATEDOCS_LOG_DIR` environment variable.

## Why?
On the AI tool I used, `cratedocs` would always create the `logs` directory in the root of the project. That's not a desired functionality. As it was introducing unnecessary files to my workspace.

## How?
The MCP server checks for the `CRATEDOCS_LOG_DIR` environment variable, if one is set it uses that one for logging, if not, it goes back to the default `logs` directory in the current working directory.